### PR TITLE
preload wordlist

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -3,11 +3,7 @@
 
 name: Python package
 
-on:
-  push:
-    branches: [ $default-branch ]
-  pull_request:
-    branches: [ $default-branch ]
+on: [push]
 
 jobs:
   build:
@@ -29,6 +25,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest pytest-cov
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        pip install -e .
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
@@ -38,3 +35,10 @@ jobs:
     - name: Test with pytest
       run: |
         pytest nemony --doctest-modules --junitxml=tests/test-results.xml --cov=com --cov-report=xml --cov-report=html
+    - name: Upload pytest test results
+      uses: actions/upload-artifact@v3
+      with:
+          name: pytest-results-${{ matrix.python-version }}
+          path: junit/test-results-${{ matrix.python-version }}.xml
+      # Use always() to always run this step to publish test results when there are test failures
+      if: ${{ always() }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # 🧠 nemony
 
+![GitHub Workflow Status (with branch)](https://img.shields.io/github/actions/workflow/status/scbirlab/nemony/python-publish.yml)
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/nemony)
+![PyPI](https://img.shields.io/pypi/v/nemony)
+
 Deterministically encode text as mnemonic adjective-noun pairs.
 
 The same text should be identically encoded across systems. While
@@ -100,7 +104,7 @@ options:
                         Output file. Default STDOUT.
 ```
 
-### Python package
+### Python API
 
 You can import **nemony** and use it to encode Python objects, as
 long as they can be converted to strings.
@@ -121,14 +125,14 @@ As a convenience, you can also use the SHA-256 hashing functions
 (which use Python standard library `hashlib`).
 
 ```python
->>> hash('world')
+>>> nm.hash('world')
 '486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7'
->>> hash('world', n=8)
+>>> nm.hash('world', n=8)
 '486ea462'
->>> hash(5., n=8)
+>>> nm.hash(5., n=8)
 'a19a1584'
 ```
 
 #### Documentation
 
-Check the Python API [here](https://nemony.readthedocs.io/).
+Check the Python API at [ReadTheDocs](https://nemony.readthedocs.io/).

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,6 +22,6 @@ collisions (two texts having the same mnemonic) can happen.
 
 
 Source
-======
+------
 
-`GitHub <https://github.com/scbirlab/nemony>`_
+Find the source on `GitHub <https://github.com/scbirlab/nemony>`_.

--- a/docs/source/usage.md
+++ b/docs/source/usage.md
@@ -74,7 +74,7 @@ options:
                         Output file. Default STDOUT.
 ```
 
-## Python package
+## Python API
 
 You can import **nemony** and use it to encode Python objects, as
 long as they can be converted to strings.
@@ -95,10 +95,10 @@ As a convenience, you can also use the SHA-256 hashing functions
 (which use Python standard library `hashlib`).
 
 ```python
->>> hash('world')
+>>> nm.hash('world')
 '486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7'
->>> hash('world', n=8)
+>>> nm.hash('world', n=8)
 '486ea462'
->>> hash(5., n=8)
+>>> nm.hash(5., n=8)
 'a19a1584'
 ```

--- a/nemony/cli.py
+++ b/nemony/cli.py
@@ -3,23 +3,28 @@
 import argparse
 import sys
 
-from .nemony import encode, _get_corpus
+from .nemony import _check_version, _get_wordlist, encode 
 
 def _interactive_session() -> None:
 
-    print("\n(Ctrl-C to exit.)\nWhat would you like to encode?\n",
-          file=sys.stderr)
+    print("", "(Ctrl-C to exit.)", "What would you like to encode?",
+          sep='\n',
+          file=sys.stderr, flush=True)
 
     while True:
 
         try:
+
             x = input("?> ")
-
-            print(encode(x))
-
-        except KeyboardInterrupt:
+        
+        except KeyboardInterrupt or EOFError:
 
             break
+
+        else:
+
+            if len(x) > 0:
+                print(encode(x), flush=True)
 
     return None
 
@@ -45,11 +50,12 @@ def main() -> None:
     
     args = parser.parse_args()
 
-    adjectives, nouns = _get_corpus()
+    adjectives, nouns = _get_wordlist()
+    version_name = _check_version()
 
     print('\n## MNEMO: Generate adjective-noun mnemonics',
           file=sys.stderr)
-    print(f'Word list version: {encode(adjectives + nouns)}\n',
+    print(f'Word list version: {version_name}\n',
           f'- Number of adjectives: {len(adjectives)}\n',
           f'- Number of nouns: {len(nouns)}\n',
           f'- Combinations: {len(adjectives) * len(nouns)}\n',

--- a/nemony/nemony.py
+++ b/nemony/nemony.py
@@ -15,46 +15,6 @@ import sys
 import yaml
 
 
-def _get_corpus() -> Sequence[Sequence[str]]:
-
-    _data_path = os.path.join(os.path.dirname(__file__), 
-                              'words.yml')
-
-    with open(_data_path, 'r') as f:
-        _words = yaml.safe_load(f)
-
-    versions = _words['versions']
-    word_lists = _words['word lists']
-    latest_version = versions[0]
-
-    adjectives = list(set(word_lists[latest_version]['adjectives']))
-    adjectives.sort()
-    nouns = list(set(word_lists[latest_version]['nouns']))
-    nouns.sort()
-
-    version_name = encode(adjectives + nouns,
-                          wordlist=(adjectives, nouns))
-    
-    if version_name != latest_version:
-
-        print(f'INFO: Word list has changed compared to {latest_version}. '
-              f'Saving new list as {version_name}.',
-              file=sys.stderr)
-        _words['versions'] = [version_name] + _words['versions'][1:]
-        del  _words['word lists'][latest_version]
-        _words['word lists'][version_name] = dict(adjectives=adjectives, 
-                                                  nouns=nouns)
-
-        with open(_data_path, 'w') as f:
-            yaml.safe_dump(_words, f, 
-                    default_flow_style=False, 
-                    width=80, indent=1)
-            
-        return _get_corpus()
-
-    return adjectives, nouns
-
-
 @singledispatch
 def hash(x, *args, **kwargs) -> str:
 
@@ -176,7 +136,7 @@ def encode(x: Union[str, int, float, Iterable],
 
     """
 
-    adjectives, nouns = wordlist or _get_corpus()
+    adjectives, nouns = wordlist or _DEFAULT_WORDLIST
 
     # Take the first n characters of the hash and convert to an integer
     integer = int(hash(x, n=n), base=16)
@@ -187,3 +147,46 @@ def encode(x: Union[str, int, float, Iterable],
     mnemonic = sep.join((adjective, noun))
 
     return mnemonic
+
+
+def _get_corpus() -> Sequence[Sequence[str]]:
+
+    _data_path = os.path.join(os.path.dirname(__file__), 
+                              'words.yml')
+
+    with open(_data_path, 'r') as f:
+        _words = yaml.safe_load(f)
+
+    versions = _words['versions']
+    word_lists = _words['word lists']
+    latest_version = versions[0]
+
+    adjectives = list(set(word_lists[latest_version]['adjectives']))
+    adjectives.sort()
+    nouns = list(set(word_lists[latest_version]['nouns']))
+    nouns.sort()
+
+    version_name = encode(adjectives + nouns,
+                          wordlist=(adjectives, nouns))
+    
+    if version_name != latest_version:
+
+        print(f'INFO: Word list has changed compared to {latest_version}. '
+              f'Saving new list as {version_name}.',
+              file=sys.stderr)
+        _words['versions'] = [version_name] + _words['versions'][1:]
+        del  _words['word lists'][latest_version]
+        _words['word lists'][version_name] = dict(adjectives=adjectives, 
+                                                  nouns=nouns)
+
+        with open(_data_path, 'w') as f:
+            yaml.safe_dump(_words, f, 
+                    default_flow_style=False, 
+                    width=80, indent=1)
+            
+        return _get_corpus()
+
+    return adjectives, nouns
+
+
+_DEFAULT_WORDLIST = _get_corpus()

--- a/nemony/nemony.py
+++ b/nemony/nemony.py
@@ -4,6 +4,8 @@ Currently supports strings, iterables, floats and ints.
 
 """
 
+from __future__ import annotations
+
 from typing import Union
 from collections.abc import Sequence, Iterable
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nemony"
-version = "0.0.1"
+version = "0.0.2"
 authors = [
   { name="Eachan Johnson", email="eachan.johnson@crick.ac.uk" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 description = "Convert text to adjective-noun mnemonics."
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.8"
 license = {file = "LICENSE.txt"}
 keywords = ["mnemonic", "hash", "programming"]
 
@@ -20,6 +20,8 @@ classifiers = [
 
   "License :: OSI Approved :: MIT License",
 
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3 :: Only",


### PR DESCRIPTION
- Take wordlist loading outside encode()
- Separate version check from corpus load
- Update docs
- Drop min Python to 3.8
- Improve test workflow
